### PR TITLE
Update Travis CI Test setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 dist: xenial
 python:
-  - "3.6"
   - "3.7"
   - "3.9"
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: xenial
 python:
   - "3.6"
   - "3.7"
+  - "3.9"
 env:
   global:
     - DATABASE_URL_TEST="postgres://postgres@localhost/test_solawi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ python:
   - "3.6"
   - "3.7"
 env:
-  - DATABASE_URL_TEST="postgres://postgres@localhost/test_solawi"
+  global:
+    - DATABASE_URL_TEST="postgres://postgres@localhost/test_solawi"
+    - SECRET_KEY="hunter2"
 services:
   - postgresql
 install:


### PR DESCRIPTION
This PR:
- Provides the `SECRET_KEY` environment variable in the tests
- Adds Python 3.9 to the build matrix
- Drops Python 3.6 from the build matrix