### PR TITLE
Improve calculations where end date is in the future

### DIFF
--- a/migrations/sql/get_expected_today_1.sql
+++ b/migrations/sql/get_expected_today_1.sql
@@ -1,0 +1,42 @@
+CREATE OR REPLACE FUNCTION get_expected_today(IN start_date date,
+                                              IN end_date date,
+                                              IN amount decimal,
+                                              IN today date default CURRENT_DATE,
+                                              OUT amount_due decimal)
+AS
+$$
+DECLARE
+    NEW_PAYMENT_REQUIRED_DAY CONSTANT integer := 27;
+    bet_end CONSTANT date := COALESCE(end_date, today);
+    year_diff CONSTANT integer := DATE_PART('year', bet_end) - DATE_PART('year', start_date);
+    month_diff CONSTANT integer :=  DATE_PART('month', bet_end) - DATE_PART('month', start_date);
+    day_diff CONSTANT integer := DATE_PART('day', bet_end) - DATE_PART('day', start_date);
+    months decimal := year_diff * 12 + month_diff;
+
+BEGIN
+    IF DATE_PART('day', bet_end) >= NEW_PAYMENT_REQUIRED_DAY THEN
+        months = months + 1;
+    END IF;
+
+    IF CURRENT_DATE > start_date AND end_date is NULL THEN
+        -- if this bet is still active, we expect them to have payed
+        -- for the following month already
+        months = months +1;
+    END IF;
+
+    IF DATE_PART('day', start_date) >= 15 THEN
+        -- If the Bet was started at mid-month, subtract half
+        -- a month from the expected amount
+        months = months - 0.5;
+
+        if day_diff > 16 THEN
+            -- If the Bet started at a half month and today is a new
+            -- month (but no full month in the delta yet), we need to
+            -- account for one more month.
+            months = months + 1;
+        END IF;
+    END IF;
+    amount_due := months * amount;
+END
+$$
+LANGUAGE plpgsql;

--- a/migrations/sql/get_expected_today_2.sql
+++ b/migrations/sql/get_expected_today_2.sql
@@ -1,0 +1,42 @@
+CREATE OR REPLACE FUNCTION get_expected_today(IN start_date date,
+                                              IN end_date date,
+                                              IN amount decimal,
+                                              IN today date default CURRENT_DATE,
+                                              OUT amount_due decimal)
+AS
+$$
+DECLARE
+    NEW_PAYMENT_REQUIRED_DAY CONSTANT integer := 27;
+    bet_end CONSTANT date := LEAST(end_date, today);
+    year_diff CONSTANT integer := DATE_PART('year', bet_end) - DATE_PART('year', start_date);
+    month_diff CONSTANT integer :=  DATE_PART('month', bet_end) - DATE_PART('month', start_date);
+    day_diff CONSTANT integer := DATE_PART('day', bet_end) - DATE_PART('day', start_date);
+    months decimal := year_diff * 12 + month_diff;
+
+BEGIN
+    IF DATE_PART('day', bet_end) >= NEW_PAYMENT_REQUIRED_DAY THEN
+        months = months + 1;
+    END IF;
+
+    IF CURRENT_DATE > start_date AND end_date is NULL THEN
+        -- if this bet is still active, we expect them to have payed
+        -- for the following month already
+        months = months +1;
+    END IF;
+
+    IF DATE_PART('day', start_date) >= 15 THEN
+        -- If the Bet was started at mid-month, subtract half
+        -- a month from the expected amount
+        months = months - 0.5;
+
+        if day_diff > 16 THEN
+            -- If the Bet started at a half month and today is a new
+            -- month (but no full month in the delta yet), we need to
+            -- account for one more month.
+            months = months + 1;
+        END IF;
+    END IF;
+    amount_due := months * amount;
+END
+$$
+LANGUAGE plpgsql;

--- a/migrations/utils.py
+++ b/migrations/utils.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def get_sql(filename):
+    path = Path(__file__).parent.joinpath('./sql').joinpath(filename).resolve()
+    with open(path) as sql:
+        return sql.read()

--- a/migrations/versions/236c477a1a2f_improve_expected_today_calculation_if_.py
+++ b/migrations/versions/236c477a1a2f_improve_expected_today_calculation_if_.py
@@ -1,0 +1,27 @@
+"""Improve expected_today calculation if end_date is in the future
+
+Revision ID: 236c477a1a2f
+Revises: f9279763be97
+Create Date: 2021-07-03 21:56:49.564486
+
+"""
+
+# revision identifiers, used by Alembic.
+from migrations.utils import get_sql
+
+revision = '236c477a1a2f'
+down_revision = 'f9279763be97'
+
+from alembic import op
+
+
+def upgrade():
+    connection = op.get_bind()
+
+    connection.execute(get_sql('get_expected_today_2.sql'))
+
+
+def downgrade():
+    connection = op.get_bind()
+
+    connection.execute(get_sql('get_expected_today_1.sql'))

--- a/migrations/versions/f9279763be97_create_postgres_method_for_getting_.py
+++ b/migrations/versions/f9279763be97_create_postgres_method_for_getting_.py
@@ -7,60 +7,18 @@ Create Date: 2021-01-17 11:08:10.649064
 """
 
 # revision identifiers, used by Alembic.
+
 revision = 'f9279763be97'
 down_revision = 'bad0fbb450c4'
 
 from alembic import op
-import sqlalchemy as sa
+from migrations.utils import get_sql
 
 
 def upgrade():
     connection = op.get_bind()
 
-    connection.execute("""
-    CREATE OR REPLACE FUNCTION get_expected_today(IN start_date date,
-                                                  IN end_date date,
-                                                  IN amount decimal,
-                                                  IN today date default CURRENT_DATE,
-                                                  OUT amount_due decimal)
-AS  
-$$
-DECLARE 
-	NEW_PAYMENT_REQUIRED_DAY CONSTANT integer := 27;
-	bet_end CONSTANT date := COALESCE(end_date, today);
-	year_diff CONSTANT integer := DATE_PART('year', bet_end) - DATE_PART('year', start_date);
-	month_diff CONSTANT integer :=  DATE_PART('month', bet_end) - DATE_PART('month', start_date);
-	day_diff CONSTANT integer := DATE_PART('day', bet_end) - DATE_PART('day', start_date);
-	months decimal := year_diff * 12 + month_diff;
-	
-BEGIN
-	IF DATE_PART('day', bet_end) >= NEW_PAYMENT_REQUIRED_DAY THEN
-		months = months + 1;
-	END IF;
-	
-	IF CURRENT_DATE > start_date AND end_date is NULL THEN
-        -- if this bet is still active, we expect them to have payed
-	    -- for the following month already
-		months = months +1;
-	END IF;
-	
-	IF DATE_PART('day', start_date) >= 15 THEN
-        -- If the Bet was started at mid-month, subtract half
-        -- a month from the expected amount
-		months = months - 0.5;
-		
-		if day_diff > 16 THEN
-	        -- If the Bet started at a half month and today is a new
-            -- month (but no full month in the delta yet), we need to
-            -- account for one more month.
-			months = months + 1;
-		END IF;
-	END IF;
-	amount_due := months * amount;
-END
-$$ 
-LANGUAGE plpgsql;
-    """)
+    connection.execute(get_sql('get_expected_today_1.sql'))
 
 
 def downgrade():

--- a/solawi/app.py
+++ b/solawi/app.py
@@ -11,7 +11,7 @@ from flask_sqlalchemy import SQLAlchemy
 from flask_cors import CORS
 from flask_migrate import Migrate
 from raven.contrib.flask import Sentry
-
+from simplejson import JSONEncoder
 
 secret_key = os.environ.get('SECRET_KEY')
 if secret_key is None:
@@ -34,6 +34,8 @@ app.config['JWT_ACCESS_TOKEN_EXPIRES'] = 60 * 60
 app.debug = os.environ.get("DEBUG", False)
 app.logger.addHandler(logging.StreamHandler(sys.stdout))
 app.logger.setLevel(logging.ERROR)
+app.json_encoder = JSONEncoder # For automatic Decimal support
+
 jwt = JWTManager(app)
 
 sentry = Sentry(app)

--- a/test_models.py
+++ b/test_models.py
@@ -356,3 +356,14 @@ class ModelTest(DBTest):
                   )
         bet.save()
         assert share.expected_today == 150
+
+    def test_expected_at_a_time_before_the_bets_end_time(self):
+        import datetime
+        share = ShareFactory.create()
+        bet = Bet(start_date=datetime.date(2017, 1, 1),
+                  end_date=datetime.date(2017, 12, 31),
+                  value=100,
+                  share_id=share.id
+                  )
+        bet.save()
+        assert bet.expected_at(datetime.date(2017, 3, 31)) == 300


### PR DESCRIPTION
If a bet had an end-date, we would always use this to calculate the
total expected amount. This meant that if a bet had the range of
a full year entered already (Jan-Dec) with a value of 100/month,
in March we would expectd their balance to be 1200 (12*100) already
instead of the 300 that it should be. The postgres function now takes
the lesser of current date and end date to do this calculation leading
to more expected results for end users.