### PR TITLE
Set required fields in `Bet` to be non nullable

### DIFF
--- a/migrations/versions/f92f33bd3b4a_set_bet_fields_not_nullable.py
+++ b/migrations/versions/f92f33bd3b4a_set_bet_fields_not_nullable.py
@@ -1,0 +1,38 @@
+"""Set Bet fields not nullable
+
+Revision ID: f92f33bd3b4a
+Revises: 236c477a1a2f
+Create Date: 2022-03-20 09:21:10.506038
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'f92f33bd3b4a'
+down_revision = '236c477a1a2f'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+def upgrade():
+    op.alter_column('bet', 'value',
+               existing_type=sa.NUMERIC(),
+               nullable=False)
+    op.alter_column('bet', 'start_date',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=False)
+    op.alter_column('bet', 'share_id',
+               existing_type=sa.INTEGER(),
+               nullable=False)
+
+
+def downgrade():
+    op.alter_column('bet', 'share_id',
+               existing_type=sa.INTEGER(),
+               nullable=True)
+    op.alter_column('bet', 'start_date',
+               existing_type=postgresql.TIMESTAMP(),
+               nullable=True)
+    op.alter_column('bet', 'value',
+               existing_type=sa.NUMERIC(),
+               nullable=True)

--- a/solawi/models.py
+++ b/solawi/models.py
@@ -83,10 +83,10 @@ class Deposit(db.Model, BaseModel):
 
 class Bet(db.Model, BaseModel):
     id = db.Column(db.Integer, primary_key=True)  # pylint: disable=invalid-name
-    value = db.Column(db.Numeric)
-    start_date = db.Column(db.DateTime, default=datetime.date(2017, 5, 1))
+    value = db.Column(db.Numeric, nullable=False)
+    start_date = db.Column(db.DateTime, nullable=False)
     end_date = db.Column(db.DateTime)
-    share_id = db.Column(db.Integer, db.ForeignKey("share.id"))
+    share_id = db.Column(db.Integer, db.ForeignKey("share.id"), nullable=False)
 
     @property
     def currently_active(self):


### PR DESCRIPTION
We just had a situation where one of the endpoints
failed on the live version because we had stored a bet
without a value. Bets without values don't make sense
from a domain model perspective though so we should forbid them.
The same goes for bets withouts share_ids or start_dates so we
set those fields to be non nullable as well.