### PR TITLE
Add `ptyhon-dateutil` requirement

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -573,7 +573,7 @@ watchdog = ">=0.6.0"
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 
@@ -600,7 +600,7 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
 name = "sentry-sdk"
-version = "1.5.7"
+version = "1.5.8"
 description = "Python client for Sentry (https://sentry.io)"
 category = "main"
 optional = false
@@ -794,7 +794,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "90c33befb2d40f9281506c0220e1d14970e70b4a1951a9f49e2dee102a2e8f51"
+content-hash = "14473672a776e767e216eb50109c21f75e50f5690c9606ee3bc88c2619f25dac"
 
 [metadata.files]
 alembic = [
@@ -1220,8 +1220,8 @@ requests = [
     {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
 ]
 sentry-sdk = [
-    {file = "sentry-sdk-1.5.7.tar.gz", hash = "sha256:aa52da941c56b5a76fd838f8e9e92a850bf893a9eb1e33ffce6c21431d07ee30"},
-    {file = "sentry_sdk-1.5.7-py2.py3-none-any.whl", hash = "sha256:411a8495bd18cf13038e5749e4710beb4efa53da6351f67b4c2f307c2d9b6d49"},
+    {file = "sentry-sdk-1.5.8.tar.gz", hash = "sha256:38fd16a92b5ef94203db3ece10e03bdaa291481dd7e00e77a148aa0302267d47"},
+    {file = "sentry_sdk-1.5.8-py2.py3-none-any.whl", hash = "sha256:32af1a57954576709242beb8c373b3dbde346ac6bd616921def29d68846fb8c3"},
 ]
 sepaxml = [
     {file = "sepaxml-2.5.0-py3-none-any.whl", hash = "sha256:06d72ef9514e17e7b59cd49ca898e6aa9f2a895eef4282d03a443faea64f231d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ fints = "3.0.1"
 gevent = "*"
 gunicorn = "*"
 sentry-sdk = {extras = ["flask", "sqlalchemy"], version = "*"}
+python-dateutil = "*"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"


### PR DESCRIPTION
`dateutil` is used in `solawi/fints_import.py` but was
missing from the `pyproject.toml` file and hence from
the lockfile. When I tried to deploy a new version to Heroku
with the poetry buildpack enabled, the app would crash on
start since this dependency was not available at runtime.