### PR TITLE
Do not write unset fields as null to database

### DIFF
--- a/migrations/versions/3abef02994a2_mark_fields_non_nullable.py
+++ b/migrations/versions/3abef02994a2_mark_fields_non_nullable.py
@@ -1,0 +1,32 @@
+"""Mark fields non-nullable
+
+Revision ID: 3abef02994a2
+Revises: f92f33bd3b4a
+Create Date: 2022-07-13 16:34:39.599007
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '3abef02994a2'
+down_revision = 'f92f33bd3b4a'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.alter_column('deposit', 'is_security',
+               existing_type=sa.BOOLEAN(),
+               nullable=False)
+    op.alter_column('deposit', 'ignore',
+               existing_type=sa.BOOLEAN(),
+               nullable=False)
+
+
+def downgrade():
+    op.alter_column('deposit', 'ignore',
+               existing_type=sa.BOOLEAN(),
+               nullable=True)
+    op.alter_column('deposit', 'is_security',
+               existing_type=sa.BOOLEAN(),
+               nullable=True)

--- a/solawi/api.py
+++ b/solawi/api.py
@@ -243,7 +243,7 @@ class SharePatchSchema(BaseModel, extra=Extra.forbid):
 @validate()
 def patch_share(body: SharePatchSchema, share_id: int):
     share = Share.get(share_id)
-    for key, value in body.dict().items():
+    for key, value in body.dict(exclude_unset=True).items():
         setattr(share, key, value)
     share.save()
     resp = share.json
@@ -292,7 +292,7 @@ class DepositPatchSchema(BaseModel, extra=Extra.forbid):
 @validate()
 def patch_deposit(body: DepositPatchSchema, deposit_id: int):
     deposit = Deposit.get(deposit_id)
-    json = body.dict()
+    json = body.dict(exclude_unset=True)
     for field in json:
         setattr(deposit, field, json.get(field))
     deposit.save()

--- a/solawi/models.py
+++ b/solawi/models.py
@@ -59,9 +59,9 @@ class Deposit(db.Model, BaseModel):
     amount = db.Column(db.Numeric)
     # TODO: Convert to Date and rename to `date`
     timestamp = db.Column(db.DateTime)
-    is_security = db.Column(db.Boolean, default=False)
+    is_security = db.Column(db.Boolean, nullable=False, default=False)
     title = db.Column(db.Text)
-    ignore = db.Column(db.Boolean, default=False)
+    ignore = db.Column(db.Boolean, nullable=False, default=False)
     added_by = db.Column(db.Integer, db.ForeignKey("user.id"))
 
     person_id = db.Column(db.Integer, db.ForeignKey("person.id"))

--- a/test_views.py
+++ b/test_views.py
@@ -424,13 +424,15 @@ class ShareDetailsTests(AuthorizedTest):
         self.assertEqual(response.json, expected)
 
     def test_patch_share(self):
-        share = ShareFactory.create(archived=False)
+        original_note = "My little note"
+        share = ShareFactory.create(archived=False, note=original_note)
 
         response = self.app.patch(f"/api/v1/shares/{share.id}", json={"archived": True})
 
         updated_share = Share.get(share.id)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(updated_share.archived)
+        self.assertEqual(updated_share.note, original_note)
 
     def test_patch_share_validates_request(self):
         share = ShareFactory.create()
@@ -531,8 +533,10 @@ class DepositTest(AuthorizedTest):
         response = self.app.patch(f"/api/v1/deposits/{deposit.id}", json={"ignore": True})
 
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json["deposit"]["is_security"], False)
         updated_deposit = Deposit.get(deposit.id)
         self.assertTrue(updated_deposit.ignore)
+        self.assertIs(updated_deposit.is_security, False)
 
     def test_patch_validates_payload(self):
         deposit = DepositFactory.create(ignore=False)


### PR DESCRIPTION
 With the current code, when a user would send a request    where an `Optional` field was not set, pydantic would    return that as `None` to the code and we would then    continue to write this `None`/`null` value to the database.    This means that when users e.g. tried to mark a deposit as    `ignore`, the frontend would send `{"ignore": true}` which    would be turned by pydantic into    `dict(ignore=True, is_security=None)` which would then lead    us to delete the `is_security` value in the db. Adding the    `exclude_unset` parameter changes the behavior in pydantic    so that only the set values are included in the returned dict.    With this change, we now only update the values that are actually