### PR TITLE
Reset `password_changed_at` to `None` when changing from CLI

### DIFF
--- a/solawi/commands.py
+++ b/solawi/commands.py
@@ -26,6 +26,7 @@ def change_password(email):
     if not user:
         raise click.UsageError(f'No user found for e-mail "{email}"')
     user.password = getpass()
+    user.password_changed_at = None
     user.save()
     click.echo(f"Updated user {user}")
 


### PR DESCRIPTION
We do this to force users to change their password on the first login.