### PR TITLE
Use plain dates for bet start/end times

### DIFF
--- a/migrations/versions/e515c374708a_turn_bet_datetimtes_into_dates.py
+++ b/migrations/versions/e515c374708a_turn_bet_datetimtes_into_dates.py
@@ -1,0 +1,38 @@
+"""Turn Bet datetimtes into dates
+
+Revision ID: e515c374708a
+Revises: d7e58ce0ffec
+Create Date: 2025-02-08 06:51:00.347086
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'e515c374708a'
+down_revision = 'd7e58ce0ffec'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+def upgrade():
+    with op.batch_alter_table('bet', schema=None) as batch_op:
+        batch_op.alter_column('start_date',
+               existing_type=postgresql.TIMESTAMP(),
+               type_=sa.Date(),
+               existing_nullable=False)
+        batch_op.alter_column('end_date',
+               existing_type=postgresql.TIMESTAMP(),
+               type_=sa.Date(),
+               existing_nullable=True)
+
+
+def downgrade():
+    with op.batch_alter_table('bet', schema=None) as batch_op:
+        batch_op.alter_column('end_date',
+               existing_type=sa.Date(),
+               type_=postgresql.TIMESTAMP(),
+               existing_nullable=True)
+        batch_op.alter_column('start_date',
+               existing_type=sa.Date(),
+               type_=postgresql.TIMESTAMP(),
+               existing_nullable=False)

--- a/solawi/models.py
+++ b/solawi/models.py
@@ -100,22 +100,21 @@ class Deposit(db.Model, BaseModel):
 class Bet(db.Model, BaseModel):
     id = db.Column(db.Integer, primary_key=True)  # pylint: disable=invalid-name
     value = db.Column(db.Numeric, nullable=False)
-    # TODO: Turn into Date, not DateTime
-    start_date = db.Column(db.DateTime, nullable=False)
-    end_date = db.Column(db.DateTime)
+    start_date: date = db.Column(db.Date, nullable=False)
+    end_date: date = db.Column(db.Date)
     share_id = db.Column(db.Integer, db.ForeignKey("share.id"), nullable=False)
 
     @property
     def currently_active(self):
-        return (not self.end_date) or (self.end_date.date() > datetime.date.today())
+        return (not self.end_date) or (self.end_date > datetime.date.today())
 
     def expected_at(self, date):
         with db.engine.connect() as connection:
             return connection.execute(
                 text(
                     """
-              SELECT get_expected_today(bet.start_date::date,
-                                        bet.end_date::date,
+              SELECT get_expected_today(bet.start_date,
+                                        bet.end_date,
                                         bet.value,
                                         :date
                                        )
@@ -132,8 +131,8 @@ class Bet(db.Model, BaseModel):
             return connection.execute(
                 text(
                     """
-              SELECT get_expected_today(bet.start_date::date,
-                                        bet.end_date::date,
+              SELECT get_expected_today(bet.start_date,
+                                        bet.end_date,
                                         bet.value
                                        )
               from bet

--- a/test_models.py
+++ b/test_models.py
@@ -58,7 +58,7 @@ class BetTest(DBTest):
         bet = BetFactory(share=share)
 
         expected = {
-            "start_date": datetime(2018, 1, 1, 0, 0),
+            "start_date": date(2018, 1, 1),
             "end_date": None,
             "id": bet.id,
             "value": Decimal("90"),
@@ -114,7 +114,7 @@ class ShareTest(DBTest):
         BetFactory(share=share, start_date=date(2019, 1, 1))
         BetFactory(share=share, start_date=date(2018, 1, 1), end_date=date(2018, 12, 31))
 
-        assert share.join_date == datetime(2018, 1, 1)
+        assert share.join_date == date(2018, 1, 1)
 
 
 class PersonTest(DBTest):

--- a/test_views.py
+++ b/test_views.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import date
 from unittest.mock import patch
 
 import pytest
@@ -67,7 +67,7 @@ class AuthorizedViewsTests(AuthorizedTest):
                 "phone": "001234",
                 "share_id": share1.id,
                 "station_name": "Station 1",
-                "join_date": "2018-01-01T00:00:00",
+                "join_date": "2018-01-01",
             },
             {
                 "email": "paula@example.org",
@@ -76,7 +76,7 @@ class AuthorizedViewsTests(AuthorizedTest):
                 "phone": "001234",
                 "share_id": share1.id,
                 "station_name": "Station 1",
-                "join_date": "2018-01-01T00:00:00",
+                "join_date": "2018-01-01",
             },
             {
                 "email": "jane@example.org",
@@ -85,7 +85,7 @@ class AuthorizedViewsTests(AuthorizedTest):
                 "phone": "0055689",
                 "share_id": share2.id,
                 "station_name": "Station 2",
-                "join_date": "2019-01-15T00:00:00",
+                "join_date": "2019-01-15",
             },
         ]
 
@@ -362,7 +362,7 @@ class SharesTests(AuthorizedTest):
                             "end_date": None,
                             "id": 1,
                             "share_id": 1,
-                            "start_date": "2018-01-01T00:00:00",
+                            "start_date": "2018-01-01",
                             "value": 99,
                         }
                     ],
@@ -378,7 +378,7 @@ class SharesTests(AuthorizedTest):
                             "end_date": None,
                             "id": 2,
                             "share_id": 2,
-                            "start_date": "2018-01-01T00:00:00",
+                            "start_date": "2018-01-01",
                             "value": 102,
                         }
                     ],
@@ -516,7 +516,7 @@ class BetDetailsTests(AuthorizedTest):
 
         payload = {
             "value": 99,
-            "start_date": bet.start_date.strftime("%Y-%m-%d"),
+            "start_date": bet.start_date,
             "share_id": 12,  # this is not allowed and should trigger a 400
         }
 
@@ -555,7 +555,7 @@ class BetDetailsTests(AuthorizedTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(db.session.query(Bet).count(), 1)
         self.assertEqual(bet.value, 99)
-        self.assertEqual(bet.start_date, datetime(2019, 1, 1, 0, 0))
+        self.assertEqual(bet.start_date, date(2019, 1, 1))
         self.assertEqual(bet.end_date, None)
 
     @pytest.mark.usefixtures("app_ctx")


### PR DESCRIPTION
For the duration that a bet is valid, we only care about the dates, not the specific timestamp. This should be reflected in the database and models.